### PR TITLE
Add OPC Publisher

### DIFF
--- a/deployment/build-and-deploy-images.ps1
+++ b/deployment/build-and-deploy-images.ps1
@@ -35,11 +35,11 @@ $acrName = (az acr list -g $ResourceGroupName --query [].name -o tsv)
 
 # ----- Build and Push Containers
 Write-Title("Build and Push Containers")
-$deplymentDir = Get-Location
+$deploymentDir = Get-Location
 Set-Location -Path ../iotedge/Distributed.IoT.Edge
 az acr build --image datagatewaymodule:$deploymentId --registry $acrName --file Distributed.IoT.Edge.DataGatewayModule/Dockerfile .
 az acr build --image simulatedtemperaturesensormodule:$deploymentId --registry $acrName --file Distributed.IoT.Edge.SimulatedTemperatureSensorModule/Dockerfile .
-Set-Location -Path $deplymentDir
+Set-Location -Path $deploymentDir
 
 # ----- Build and Push Containers (OPC Publisher)
 Write-Title("Build and Push Containers (OPC Publisher)")
@@ -52,7 +52,7 @@ git pull
 $Env:BUILD_SOURCEBRANCH = "feature/dapr-adapter"
 $Env:Version_Prefix = $deploymentId
 .\tools\scripts\acr-build.ps1 -Path .\modules\src\Microsoft.Azure.IIoT.Modules.OpcUa.Publisher\src -Registry $acrName
-Set-Location -Path $deplymentDir
+Set-Location -Path $deploymentDir
 
 # ----- Run Helm
 Write-Title("Upgrade Pod/Containers with Helm in Cluster")

--- a/deployment/build-and-deploy-images.ps1
+++ b/deployment/build-and-deploy-images.ps1
@@ -45,7 +45,7 @@ Set-Location -Path $deplymentDir
 Write-Title("Build and Push Containers (OPC Publisher)")
 if (!(Test-Path .\..\..\Industrial-IoT-Temp))
 {
-    git clone -b feature/dapr-adapter https://github.com/simonjaeger/Industrial-IoT .\..\..\Industrial-IoT-Temp
+    git clone -b feature/dapr-adapter https://github.com/suneetnangia/Industrial-IoT .\..\..\Industrial-IoT-Temp
 }
 Set-Location -Path .\..\..\Industrial-IoT-Temp
 git pull

--- a/deployment/build-and-deploy-images.ps1
+++ b/deployment/build-and-deploy-images.ps1
@@ -41,13 +41,30 @@ az acr build --image datagatewaymodule:$deploymentId --registry $acrName --file 
 az acr build --image simulatedtemperaturesensormodule:$deploymentId --registry $acrName --file Distributed.IoT.Edge.SimulatedTemperatureSensorModule/Dockerfile .
 Set-Location -Path $deplymentDir
 
+# ----- Build and Push Containers (OPC Publisher)
+Write-Title("Build and Push Containers (OPC Publisher)")
+if (!(Test-Path .\..\..\Industrial-IoT-Temp))
+{
+    git clone -b feature/dapr-adapter https://github.com/simonjaeger/Industrial-IoT .\..\..\Industrial-IoT-Temp
+}
+Set-Location -Path .\..\..\Industrial-IoT-Temp
+git pull
+$Env:BUILD_SOURCEBRANCH = "feature/dapr-adapter"
+$Env:Version_Prefix = $deploymentId
+.\tools\scripts\acr-build.ps1 -Path .\modules\src\Microsoft.Azure.IIoT.Modules.OpcUa.Publisher\src -Registry $acrName
+Set-Location -Path $deplymentDir
+
 # ----- Run Helm
 Write-Title("Upgrade Pod/Containers with Helm in Cluster")
 $datagatewaymoduleimage = $acrName + ".azurecr.io/datagatewaymodule:" + $deploymentId
 $simtempimage = $acrName + ".azurecr.io/simulatedtemperaturesensormodule:" + $deploymentId
+$opcplcimage = "mcr.microsoft.com/iotedge/opc-plc:2.2.0"
+$opcpublisherimage = $acrName + ".azurecr.io/dapr-adapter/iotedge/opc-publisher:" + $deploymentId
 helm upgrade iot-edge-accelerator ./helm/iot-edge-accelerator `
     --set-string images.datagatewaymodule="$datagatewaymoduleimage" `
     --set-string images.simulatedtemperaturesensormodule="$simtempimage" `
+    --set-string images.opcplcmodule="$opcplcimage" `
+    --set-string images.opcpublishermodule="$opcpublisherimage" `
 
 $runningTime = New-TimeSpan -Start $startTime
 

--- a/deployment/deploy-aks-dapr.ps1
+++ b/deployment/deploy-aks-dapr.ps1
@@ -44,11 +44,11 @@ $eventHubConnectionString = $r.properties.outputs.eventHubConnectionString.value
 
 # ----- Build and Push Containers
 Write-Title("Build and Push Containers")
-$deplymentDir = Get-Location
+$deploymentDir = Get-Location
 Set-Location -Path ../iotedge/Distributed.IoT.Edge
 az acr build --image datagatewaymodule:$deploymentId --registry $acrName --file Distributed.IoT.Edge.DataGatewayModule/Dockerfile .
 az acr build --image simulatedtemperaturesensormodule:$deploymentId --registry $acrName --file Distributed.IoT.Edge.SimulatedTemperatureSensorModule/Dockerfile .
-Set-Location -Path $deplymentDir
+Set-Location -Path $deploymentDir
 
 # ----- Build and Push Containers (OPC Publisher)
 Write-Title("Build and Push Containers (OPC Publisher)")
@@ -61,7 +61,7 @@ git pull
 $Env:BUILD_SOURCEBRANCH = "feature/dapr-adapter"
 $Env:Version_Prefix = $deploymentId
 .\tools\scripts\acr-build.ps1 -Path .\modules\src\Microsoft.Azure.IIoT.Modules.OpcUa.Publisher\src -Registry $acrName
-Set-Location -Path $deplymentDir
+Set-Location -Path $deploymentDir
 
 # ----- Get Cluster Credentials
 Write-Title("Get AKS Credentials")

--- a/deployment/deploy-aks-dapr.ps1
+++ b/deployment/deploy-aks-dapr.ps1
@@ -54,7 +54,7 @@ Set-Location -Path $deplymentDir
 Write-Title("Build and Push Containers (OPC Publisher)")
 if (!(Test-Path .\..\..\Industrial-IoT-Temp))
 {
-    git clone -b feature/dapr-adapter https://github.com/simonjaeger/Industrial-IoT .\..\..\Industrial-IoT-Temp
+    git clone -b feature/dapr-adapter https://github.com/suneetnangia/Industrial-IoT .\..\..\Industrial-IoT-Temp
 }
 Set-Location -Path .\..\..\Industrial-IoT-Temp
 git pull

--- a/deployment/deploy-aks-dapr.ps1
+++ b/deployment/deploy-aks-dapr.ps1
@@ -50,6 +50,19 @@ az acr build --image datagatewaymodule:$deploymentId --registry $acrName --file 
 az acr build --image simulatedtemperaturesensormodule:$deploymentId --registry $acrName --file Distributed.IoT.Edge.SimulatedTemperatureSensorModule/Dockerfile .
 Set-Location -Path $deplymentDir
 
+# ----- Build and Push Containers (OPC Publisher)
+Write-Title("Build and Push Containers (OPC Publisher)")
+if (!(Test-Path .\..\..\Industrial-IoT-Temp))
+{
+    git clone -b feature/dapr-adapter https://github.com/simonjaeger/Industrial-IoT .\..\..\Industrial-IoT-Temp
+}
+Set-Location -Path .\..\..\Industrial-IoT-Temp
+git pull
+$Env:BUILD_SOURCEBRANCH = "feature/dapr-adapter"
+$Env:Version_Prefix = $deploymentId
+.\tools\scripts\acr-build.ps1 -Path .\modules\src\Microsoft.Azure.IIoT.Modules.OpcUa.Publisher\src -Registry $acrName
+Set-Location -Path $deplymentDir
+
 # ----- Get Cluster Credentials
 Write-Title("Get AKS Credentials")
 az aks get-credentials --admin --name $aksName --resource-group $resourceGroupName --overwrite-existing
@@ -74,9 +87,13 @@ helm install redis bitnami/redis --wait
 Write-Title("Install Pod/Containers with Helm in Cluster")
 $datagatewaymoduleimage = $acrName + ".azurecr.io/datagatewaymodule:" + $deploymentId
 $simtempimage = $acrName + ".azurecr.io/simulatedtemperaturesensormodule:" + $deploymentId
+$opcplcimage = "mcr.microsoft.com/iotedge/opc-plc:2.2.0"
+$opcpublisherimage = $acrName + ".azurecr.io/dapr-adapter/iotedge/opc-publisher:" + $deploymentId
 helm install iot-edge-accelerator ./helm/iot-edge-accelerator `
     --set-string images.datagatewaymodule="$datagatewaymoduleimage" `
     --set-string images.simulatedtemperaturesensormodule="$simtempimage" `
+    --set-string images.opcplcmodule="$opcplcimage" `
+    --set-string images.opcpublishermodule="$opcpublisherimage" `
     --set-string dataGatewayModule.eventHubConnectionString="$eventHubConnectionString" `
     --set-string dataGatewayModule.storageAccountName="$storageName" `
     --set-string dataGatewayModule.storageAccountKey="$storageKey"

--- a/deployment/helm/iot-edge-accelerator/pn.json
+++ b/deployment/helm/iot-edge-accelerator/pn.json
@@ -1,0 +1,16 @@
+[
+  {
+    "EndpointUrl": "opc.tcp://localhost:50000",
+    "UseSecurity": false,
+    "DataSetWriterId": "9f70b74d-248f-4ba3-90fe-c1de907a2f7b",
+    "DataSetWriterGroup": "9f70b74d-248f-4ba3-90fe-c1de907a2f7b",
+    "OpcNodes": [
+      {
+        "Id": "ns=2;s=FastUInt1",
+        "DisplayName": "FastNode1",
+        "OpcSamplingInterval": 1,
+        "OpcPublishingInterval": 0
+      }
+    ]
+  }
+]

--- a/deployment/helm/iot-edge-accelerator/templates/dapr/event-hub-pub-sub.yaml
+++ b/deployment/helm/iot-edge-accelerator/templates/dapr/event-hub-pub-sub.yaml
@@ -20,12 +20,13 @@ spec:
   #   value: 0
   # Lock down type of access for each service.
   - name: publishingScopes
-    value: "simulated-temperature-sensor-module=;data-gateway-module=telemetry"
+    value: "simulated-temperature-sensor-module=;data-gateway-module=telemetry;opc-publisher-module=telemetry"
   - name: subscriptionScopes
-    value: "simulated-temperature-sensor-module=;data-gateway-module="
+    value: "simulated-temperature-sensor-module=;data-gateway-module=;opc-publisher-module="
   # Lock down the topics on this pubsub component.
   - name: allowedTopics
     value: "telemetry"
 scopes:
 - data-gateway-module
+- opc-publisher-module
 {{ end }}

--- a/deployment/helm/iot-edge-accelerator/templates/dapr/redis-pub-sub.yaml
+++ b/deployment/helm/iot-edge-accelerator/templates/dapr/redis-pub-sub.yaml
@@ -16,9 +16,9 @@ spec:
       key: redis-password
   # Lock down type of access for each service.
   - name: publishingScopes
-    value: "simulated-temperature-sensor-module=telemetry;data-gateway-module="
+    value: "simulated-temperature-sensor-module=telemetry;data-gateway-module=;opc-publisher-module=telemetry"
   - name: subscriptionScopes
-    value: "simulated-temperature-sensor-module=;data-gateway-module=telemetry"
+    value: "simulated-temperature-sensor-module=;data-gateway-module=telemetry;opc-publisher-module="
   # Lock down the topics on this pubsub component.
   - name: allowedTopics
     value: "telemetry"
@@ -29,3 +29,4 @@ spec:
 scopes:
 - data-gateway-module
 - simulated-temperature-sensor-module
+- opc-publisher-module

--- a/deployment/helm/iot-edge-accelerator/templates/system-modules/opc-publisher-module.yaml
+++ b/deployment/helm/iot-edge-accelerator/templates/system-modules/opc-publisher-module.yaml
@@ -1,0 +1,65 @@
+# System OPC PLC/OPC Publisher module/pod
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opc-publisher-configmap
+  labels:
+    app: opc-publisher-module
+data:
+  pn.json: |-
+{{ .Files.Get "pn.json" | indent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opc-publisher-module-deployment
+  labels:
+    app: opc-publisher-module
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opc-publisher-module
+  template:
+    metadata:
+      labels:
+        app: opc-publisher-module
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "opc-publisher-module"
+        dapr.io/app-protocol: "grpc"
+    spec:
+      volumes:
+        - name: opc-publisher-volume
+          configMap:
+            name: opc-publisher-configmap
+            items:
+            - key: pn.json
+              path: pn.json
+      containers:
+      - name: opc-plc-module
+        image: {{ .Values.images.opcplcmodule }}
+        imagePullPolicy: Always
+        args: 
+        - --pn=50000 
+        - --aa 
+        - --fn=40 
+        - --vfr=1000
+        ports:
+        - containerPort: 50000
+      - name: opc-publisher-module
+        image: {{ .Values.images.opcpublishermodule }}
+        imagePullPolicy: Always
+        args: 
+        - --aa
+        - --pf
+        - /etc/opcpublisher/pn.json
+        - --mm
+        - PubSub
+        - --dapr
+        - PubSub=local-pub-sub;Topic=telemetry
+        volumeMounts:
+        - name: opc-publisher-volume
+          mountPath: /etc/opcpublisher/pn.json
+          subPath: pn.json
+      restartPolicy: Always

--- a/deployment/helm/iot-edge-accelerator/templates/system-modules/opc-publisher-module.yaml
+++ b/deployment/helm/iot-edge-accelerator/templates/system-modules/opc-publisher-module.yaml
@@ -55,9 +55,9 @@ spec:
         - --pf
         - /etc/opcpublisher/pn.json
         - --mm
-        - PubSub
+        - {{ .Values.opcPublisherModule.mm | quote }}
         - --dapr
-        - PubSub=local-pub-sub;Topic=telemetry
+        - {{ printf "PubSub=%s;Topic=%s" .Values.opcPublisherModule.pubsub .Values.opcPublisherModule.topic | quote }}
         volumeMounts:
         - name: opc-publisher-volume
           mountPath: /etc/opcpublisher/pn.json

--- a/deployment/helm/iot-edge-accelerator/templates/system-modules/simulated-temperature-sensor-module.yaml
+++ b/deployment/helm/iot-edge-accelerator/templates/system-modules/simulated-temperature-sensor-module.yaml
@@ -1,28 +1,28 @@
-# Simulated temperature sensor module/pod
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: simulated-temperature-sensor-deployment
-  labels:
-    app: simulated-temperature-sensor-module
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: simulated-temperature-sensor-module
-  template:
-    metadata:
-      labels:
-        app: simulated-temperature-sensor-module
-      annotations:
-        dapr.io/enabled: "true"
-        dapr.io/app-id: "simulated-temperature-sensor-module"
-        # Use gRPC for app <--> dapr sidecar
-        dapr.io/app-protocol: "grpc"
-    spec:
-      containers:
-      - name: simulated-temperature-sensor-module
-        image: "{{ .Values.images.simulatedtemperaturesensormodule }}"
-        imagePullPolicy: Always
-        args: ["--feedIntervalInMilliseconds", "{{ .Values.simulatedTemperatureSensorFeedIntervalInMilliseconds }}"]
-      restartPolicy: Always
+# # Simulated temperature sensor module/pod
+# apiVersion: apps/v1
+# kind: Deployment
+# metadata:
+#   name: simulated-temperature-sensor-deployment
+#   labels:
+#     app: simulated-temperature-sensor-module
+# spec:
+#   replicas: 1
+#   selector:
+#     matchLabels:
+#       app: simulated-temperature-sensor-module
+#   template:
+#     metadata:
+#       labels:
+#         app: simulated-temperature-sensor-module
+#       annotations:
+#         dapr.io/enabled: "true"
+#         dapr.io/app-id: "simulated-temperature-sensor-module"
+#         # Use gRPC for app <--> dapr sidecar
+#         dapr.io/app-protocol: "grpc"
+#     spec:
+#       containers:
+#       - name: simulated-temperature-sensor-module
+#         image: "{{ .Values.images.simulatedtemperaturesensormodule }}"
+#         imagePullPolicy: Always
+#         args: ["--feedIntervalInMilliseconds", "{{ .Values.simulatedTemperatureSensorFeedIntervalInMilliseconds }}"]
+#       restartPolicy: Always

--- a/deployment/helm/iot-edge-accelerator/templates/system-modules/simulated-temperature-sensor-module.yaml
+++ b/deployment/helm/iot-edge-accelerator/templates/system-modules/simulated-temperature-sensor-module.yaml
@@ -1,28 +1,28 @@
-# # Simulated temperature sensor module/pod
-# apiVersion: apps/v1
-# kind: Deployment
-# metadata:
-#   name: simulated-temperature-sensor-deployment
-#   labels:
-#     app: simulated-temperature-sensor-module
-# spec:
-#   replicas: 1
-#   selector:
-#     matchLabels:
-#       app: simulated-temperature-sensor-module
-#   template:
-#     metadata:
-#       labels:
-#         app: simulated-temperature-sensor-module
-#       annotations:
-#         dapr.io/enabled: "true"
-#         dapr.io/app-id: "simulated-temperature-sensor-module"
-#         # Use gRPC for app <--> dapr sidecar
-#         dapr.io/app-protocol: "grpc"
-#     spec:
-#       containers:
-#       - name: simulated-temperature-sensor-module
-#         image: "{{ .Values.images.simulatedtemperaturesensormodule }}"
-#         imagePullPolicy: Always
-#         args: ["--feedIntervalInMilliseconds", "{{ .Values.simulatedTemperatureSensorFeedIntervalInMilliseconds }}"]
-#       restartPolicy: Always
+# Simulated temperature sensor module/pod
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simulated-temperature-sensor-deployment
+  labels:
+    app: simulated-temperature-sensor-module
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: simulated-temperature-sensor-module
+  template:
+    metadata:
+      labels:
+        app: simulated-temperature-sensor-module
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "simulated-temperature-sensor-module"
+        # Use gRPC for app <--> dapr sidecar
+        dapr.io/app-protocol: "grpc"
+    spec:
+      containers:
+      - name: simulated-temperature-sensor-module
+        image: "{{ .Values.images.simulatedtemperaturesensormodule }}"
+        imagePullPolicy: Always
+        args: ["--feedIntervalInMilliseconds", "{{ .Values.simulatedTemperatureSensorFeedIntervalInMilliseconds }}"]
+      restartPolicy: Always

--- a/deployment/helm/iot-edge-accelerator/values.yaml
+++ b/deployment/helm/iot-edge-accelerator/values.yaml
@@ -7,6 +7,12 @@ dataGatewayModule:
   storageAccountName: "replace_with_storage_account_name_at_deploy_time"
   storageAccountKey: "replace_with_storage_account_key_at_deploy_time"
 
+# OPC Publisher module settings
+opcPublisherModule:
+  mm: PubSub
+  pubsub: local-pub-sub
+  topic: telemetry
+
 images:
   datagatewaymodule:
   simulatedtemperaturesensormodule:

--- a/deployment/helm/iot-edge-accelerator/values.yaml
+++ b/deployment/helm/iot-edge-accelerator/values.yaml
@@ -10,3 +10,5 @@ dataGatewayModule:
 images:
   datagatewaymodule:
   simulatedtemperaturesensormodule:
+  opcplcmodule:
+  opcpublishermodule:


### PR DESCRIPTION
Adding an OPC Publisher module together with an OPC PLC to generate data. Currently, the deployment script builds the OPC Publisher separately. 